### PR TITLE
feat: add template for node-spa-nginx-yarn

### DIFF
--- a/template/node-spa-nginx-yarn/.dockerignore
+++ b/template/node-spa-nginx-yarn/.dockerignore
@@ -1,0 +1,1 @@
+*/node_modules

--- a/template/node-spa-nginx-yarn/Dockerfile
+++ b/template/node-spa-nginx-yarn/Dockerfile
@@ -1,0 +1,23 @@
+ARG NODE_FROM=node:lts
+ARG NGINX_FROM=nginx:stable
+
+FROM ${NODE_FROM} as builder
+
+COPY service/package.json service/yarn.lock ./
+RUN yarn
+
+# COPY service files and folders
+COPY service/ ./
+ARG BUILD_PATH=/build
+
+RUN yarn build
+
+RUN mkdir -p /static-html \
+    && cp -R ${BUILD_PATH}/* /static-html/
+
+FROM ${NGINX_FROM}
+
+# https://github.com/moby/moby/issues/34482
+COPY --from=builder /static-html/ /usr/share/nginx/html/
+
+EXPOSE 80

--- a/template/node-spa-nginx-yarn/service/index.html
+++ b/template/node-spa-nginx-yarn/service/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>Hello world</title>
+  </head>
+  <body>
+    <h1>Hello world</h1>
+  </body>
+</html>

--- a/template/node-spa-nginx-yarn/template.yml
+++ b/template/node-spa-nginx-yarn/template.yml
@@ -1,0 +1,1 @@
+language: node-spa-nginx-yarn


### PR DESCRIPTION
Added a new template for node-spa-nginx-yarn, which is the same as node-spa-nginx, but uses yarn instead of npm.