### PR TITLE
build: update dockerfile

### DIFF
--- a/template/node-spa-nginx-yarn/Dockerfile
+++ b/template/node-spa-nginx-yarn/Dockerfile
@@ -3,7 +3,7 @@ ARG NGINX_FROM=nginx:stable
 
 FROM ${NODE_FROM} as builder
 
-COPY service/package.json service/yarn.lock ./
+COPY service/package.json service/yarn.lock rollup.config.js ./
 RUN yarn
 
 # COPY service files and folders


### PR DESCRIPTION
https://jenkins.refapp.mgmt.cag.systems/job/RefApp/job/cag-components/job/master/708/console

Build currently fails because it cannot find `rollup.config.js`. Added this into Dockerfile so it is copied over.